### PR TITLE
changed react/http dependency to ^0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/jclg/php-slack-bot",
     "require": {
         "devristo/phpws": "dev-master",
-        "react/http": "dev-master"
+        "react/http": "^0.4"
     },
     "authors": [
         {


### PR DESCRIPTION
I have another PR, this is loosening the requirements for react/http

Tested with `0.4`, and it seams to work as expected. But if there is some reason I haven't seen, please do tell :)

This allows for using the bot with other tools not  requiring `dev-master`