### PR TITLE
Fix PHP notices

### DIFF
--- a/src/PhpSlackBot/Bot.php
+++ b/src/PhpSlackBot/Bot.php
@@ -97,8 +97,12 @@ class Bot {
             $command = $this->getCommand($data);
             if ($command instanceof Command\BaseCommand) {
                 $command->setClient($client);
-                $command->setChannel($data['channel']);
-                $command->setUser($data['user']);
+                if (isset($data['channel'])) {
+                    $command->setChannel($data['channel']);
+                }
+                if (isset($data['user'])) {
+                    $command->setUser($data['user']);
+                }
                 $command->setContext($this->context);
                 $command->executeCommand($data, $this->context);
             }


### PR DESCRIPTION
```
PHP Notice:  Undefined index: channel in /var/www/test/vendor/jclg/php-slack-bot/src/PhpSlackBot/Bot.php on line 100
PHP Stack trace:
PHP   1. {main}() /var/www/test/index.php:0
PHP   2. PhpSlackBot\Bot->run() /var/www/test/index.php:37
PHP   3. React\EventLoop\StreamSelectLoop->run() /var/www/test/vendor/jclg/php-slack-bot/src/PhpSlackBot/Bot.php:167
PHP   4. React\EventLoop\StreamSelectLoop->waitForStreamActivity() /var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:205
PHP   5. call_user_func:{/var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:236}() /var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:236
PHP   6. React\Stream\Stream->handleData() /var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:236
PHP   7. Evenement\EventEmitter->emit() /var/www/test/vendor/react/stream/src/Stream.php:173
PHP   8. call_user_func_array:{/var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP   9. Devristo\Phpws\Protocol\WebSocketTransport->Devristo\Phpws\Protocol\{closure}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  10. Devristo\Phpws\Protocol\WebSocketTransportHybi->handleData() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransport.php:61
PHP  11. Devristo\Phpws\Protocol\WebSocketTransportHybi->processMessageFrame() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php:109
PHP  12. Evenement\EventEmitter->emit() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php:149
PHP  13. call_user_func_array:{/var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  14. Devristo\Phpws\Client\WebSocket->Devristo\Phpws\Client\{closure}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  15. Devristo\Phpws\Reflection\FullAccessWrapper->emit() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Client/WebSocket.php:141
PHP  16. Devristo\Phpws\Reflection\FullAccessWrapper->__call() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Client/WebSocket.php:141
PHP  17. ReflectionMethod->invokeArgs() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Reflection/FullAccessWrapper.php:25
PHP  18. Evenement\EventEmitter->emit() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Reflection/FullAccessWrapper.php:25
PHP  19. call_user_func_array:{/var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  20. PhpSlackBot\Bot->PhpSlackBot\{closure}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP Notice:  Undefined index: user in /var/www/test/vendor/jclg/php-slack-bot/src/PhpSlackBot/Bot.php on line 101
PHP Stack trace:
PHP   1. {main}() /var/www/test/index.php:0
PHP   2. PhpSlackBot\Bot->run() /var/www/test/index.php:37
PHP   3. React\EventLoop\StreamSelectLoop->run() /var/www/test/vendor/jclg/php-slack-bot/src/PhpSlackBot/Bot.php:167
PHP   4. React\EventLoop\StreamSelectLoop->waitForStreamActivity() /var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:205
PHP   5. call_user_func:{/var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:236}() /var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:236
PHP   6. React\Stream\Stream->handleData() /var/www/test/vendor/react/event-loop/src/StreamSelectLoop.php:236
PHP   7. Evenement\EventEmitter->emit() /var/www/test/vendor/react/stream/src/Stream.php:173
PHP   8. call_user_func_array:{/var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP   9. Devristo\Phpws\Protocol\WebSocketTransport->Devristo\Phpws\Protocol\{closure}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  10. Devristo\Phpws\Protocol\WebSocketTransportHybi->handleData() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransport.php:61
PHP  11. Devristo\Phpws\Protocol\WebSocketTransportHybi->processMessageFrame() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php:109
PHP  12. Evenement\EventEmitter->emit() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php:149
PHP  13. call_user_func_array:{/var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  14. Devristo\Phpws\Client\WebSocket->Devristo\Phpws\Client\{closure}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  15. Devristo\Phpws\Reflection\FullAccessWrapper->emit() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Client/WebSocket.php:141
PHP  16. Devristo\Phpws\Reflection\FullAccessWrapper->__call() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Client/WebSocket.php:141
PHP  17. ReflectionMethod->invokeArgs() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Reflection/FullAccessWrapper.php:25
PHP  18. Evenement\EventEmitter->emit() /var/www/test/vendor/devristo/phpws/src/Devristo/Phpws/Reflection/FullAccessWrapper.php:25
PHP  19. call_user_func_array:{/var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
PHP  20. PhpSlackBot\Bot->PhpSlackBot\{closure}() /var/www/test/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:65
```