### PR TITLE
Add Support for Thread Reply

### DIFF
--- a/src/PhpSlackBot/Base.php
+++ b/src/PhpSlackBot/Base.php
@@ -60,13 +60,16 @@ abstract class Base {
         return $this->channel;
     }
 
-    protected function send($channel, $username, $message) {
+    protected function send($channel, $username, $message, $parent_thread = null) {
         $response = array(
                           'id' => time(),
                           'type' => 'message',
                           'channel' => $channel,
                           'text' => (!is_null($username) ? '<@'.$username.'> ' : '').$message
                           );
+        if ($parent_thread) {
+            $response['thread_ts'] = $parent_thread;
+        }
         $this->client->send(json_encode($response));
     }
 

--- a/src/PhpSlackBot/Base.php
+++ b/src/PhpSlackBot/Base.php
@@ -77,6 +77,11 @@ abstract class Base {
                 return $channel['id'];
             }
         }
+        foreach ($this->context['groups'] as $group) {
+            if ($group['name'] == $channelName) {
+                return $group['id'];
+            }
+        }
         return false;
     }
 
@@ -84,6 +89,11 @@ abstract class Base {
         foreach ($this->context['channels'] as $channel) {
             if ($channel['id'] == $channelId) {
                 return $channel['name'];
+            }
+        }
+        foreach ($this->context['groups'] as $group) {
+            if ($group['id'] == $channelId) {
+                return $group['name'];
             }
         }
         return false;


### PR DESCRIPTION
Bot can now do threaded replies if `thread_ts` is supplied. Obtained from `$message->getData()`.
```
// Bot.php
$client->on("message", function($message) use ($client, $logger){
    $data = $message->getData();
    ... // Some magical codes here
    $command->executeCommand($data, $this->context);
    ...
}
```
```
// SampleCommand.php
protected function execute($message, $context)
{
    ...
    $this->send($this->getCurrentChannel(), $this->getCurrentUser(), 'FOO', $message['thread_ts']);
}
```

Not sure why the history contains my old commit (already merged)...