### PR TITLE
Merging this will enhance the Bot class to enable a logger to be set manually

### DIFF
--- a/src/PhpSlackBot/Bot.php
+++ b/src/PhpSlackBot/Bot.php
@@ -62,7 +62,7 @@ class Bot {
     public function run() {
         if (!isset($this->params['token'])) {
             throw new \Exception('A token must be set. Please see https://my.slack.com/services/new/bot');
-	}
+        }
 
         $this->init();
         $logger = $this->logger;

--- a/src/PhpSlackBot/Bot.php
+++ b/src/PhpSlackBot/Bot.php
@@ -62,9 +62,10 @@ class Bot {
     public function run() {
         if (!isset($this->params['token'])) {
             throw new \Exception('A token must be set. Please see https://my.slack.com/services/new/bot');
-        }
-	$this->init();
-	$logger = $this->logger;
+	}
+
+        $this->init();
+        $logger = $this->logger;
 
         $loop = \React\EventLoop\Factory::create();
         $client = new \Devristo\Phpws\Client\WebSocket($this->wsUrl, $loop, $logger);
@@ -171,13 +172,13 @@ class Bot {
     }
 
     public function initLogger(\Zend\Log\LoggerInterface $logger = null) {
-	if(! is_null($logger)) {
-	    $this->logger = $logger;
-	} else {	
-	    $this->logger = new \Zend\Log\Logger();
+        if(! is_null($logger)) {
+            $this->logger = $logger;
+        } else {	
+            $this->logger = new \Zend\Log\Logger();
             $writer = new \Zend\Log\Writer\Stream("php://output");
-	    $this->logger->addWriter($writer);
-	}
+            $this->logger->addWriter($writer);
+        }
     }
 
     private function init(\Zend\Log\LoggerInterface $logger = null) {
@@ -198,11 +199,11 @@ class Bot {
         if (isset($response['error'])) {
             throw new \Exception($response['error']);
         }
-	$this->wsUrl = $response['url'];
+        $this->wsUrl = $response['url'];
 
-	if(is_null($logger)) {
-	    $this->initLogger();
-	}
+        if(is_null($logger)) {
+            $this->initLogger();
+        }
     }
 
     public function loadInternalCommands() {


### PR DESCRIPTION
I'm using the library in a project where I don't want the default logging to got to the console. Merging this Pull Request allows a developer to supply a \Zend\Log\LoggerInterface compatible logger as a replacement for the Bot class.

The following test code was used to ensure backwards api compatibility.

Then:
```$bot = new Bot();
$bot->setToken('REDACTED');
$bot->loadInternalCommands(); 
$bot->run();
```
Now:
```$logger = new \Zend\Log\Logger();
$writer = new \Zend\Log\Writer\Stream("php://output");

$bot = new Bot();
$bot->setToken('REDACTED');
$bot->initLogger($logger);
$bot->loadInternalCommands(); 
$bot->run();
```