### PR TITLE
Adds curl extension as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "require": {
         "semako/phpws": "1.0.1",
-        "react/http": "^0.4"
+        "react/http": "^0.4",
+        "ext-curl": "*"
     },
     "authors": [
         {


### PR DESCRIPTION
This simply adds the curl extension as a requirement for the library.
It crashes without curl installed.